### PR TITLE
Add a section for Python 3.9, torch 1.13.1 + CPU

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -54,6 +54,16 @@ We evaluated the CompGCN repository with the following configurations.
   pip install torch-scatter==2.1.0 -f https://data.pyg.org/whl/torch-1.13.0+cu117.html
   ```
 
+## pyTorch 1.13.1, Python 3.9, CPU
+- Install all the requirements from `pip install -r requirements.txt`.
+  - Note: If issues arise installing torch/torch_scatter or when executing the code, try to install them manually, with the following command:
+  ```commandline
+  pip install torch==1.13.1 --extra-index-url https://download.pytorch.org/whl/cpu
+  ```
+  ```commandline
+  pip install torch-scatter==2.1.0 -f https://data.pyg.org/whl/torch-1.13.1+cpu.html
+  ```
+
 # Dataset:
 
 - We use the codex-l, codex-m and codex-s datasets for knowledge graph link prediction. 


### PR DESCRIPTION
This combination is needed for Google Colab and local machines without CUDA, which want to be able to evaluate the models trained with torch 1.13.1

I admit the installation section is kind of a mess and this does not improve it further, but so is python package management. So I would add it anyway and keep fingers crossed we do not need to add more.